### PR TITLE
Fix GCS bucket name collision across environments

### DIFF
--- a/modules/cloudfunctions/storage.tf
+++ b/modules/cloudfunctions/storage.tf
@@ -1,6 +1,6 @@
 # Create GCS bucket for storing function source code
 resource "google_storage_bucket" "function_source" {
-  name                        = "${var.function_name}-source"
+  name                        = "${var.function_name}-${var.env}-source"
   project                     = module.init.app.project_id
   location                    = local.location
   force_destroy               = true


### PR DESCRIPTION
## Summary
- Add environment variable to GCS bucket name to prevent naming collisions
- Bucket names now include the environment (e.g., `function-name-tst-source`, `function-name-prd-source`)
- Fixes issue where deploying the same function across multiple environments failed due to globally unique bucket name requirements

## Test plan
- [ ] Verify Terraform plan shows bucket name change for existing deployments
- [ ] Deploy to test environment and confirm bucket is created with new naming scheme
- [ ] Ensure function source upload works correctly with new bucket name

🤖 Generated with [Claude Code](https://claude.com/claude-code)