### PR TITLE
Fix Cloud Scheduler OIDC token audience drift

### DIFF
--- a/modules/cloudfunctions/scheduler.tf
+++ b/modules/cloudfunctions/scheduler.tf
@@ -16,6 +16,7 @@ resource "google_cloud_scheduler_job" "scheduler" {
 
     oidc_token {
       service_account_email = local.service_account_email
+      audience              = google_cloudfunctions2_function.function.service_config[0].uri
     }
   }
   retry_config {


### PR DESCRIPTION
## Summary
- Explicitly set the `audience` field in the `oidc_token` block to prevent Terraform drift on every plan
- Uses the Cloud Function's service URI, matching what GCP auto-populates

Fixes #11

## Test plan
- [ ] Run `terraform plan` on an existing deployment with a scheduler - should show no changes
- [ ] Deploy a new function with scheduler and verify no drift on subsequent plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)