### PR TITLE
feat(cloudfunctions): add BigQuery remote function support

### DIFF
--- a/modules/cloudfunctions/README.md
+++ b/modules/cloudfunctions/README.md
@@ -27,6 +27,9 @@
 
 | Name | Type |
 |------|------|
+| [google_bigquery_connection.remote_function](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_connection) | resource |
+| [google_bigquery_routine.remote_function](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_routine) | resource |
+| [google_cloud_run_service_iam_member.bq_remote_function_invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service_iam_member) | resource |
 | [google_cloud_run_service_iam_member.scheduler_invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service_iam_member) | resource |
 | [google_cloud_scheduler_job.scheduler](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
 | [google_cloudfunctions2_function.function](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function) | resource |
@@ -42,6 +45,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_id"></a> [app\_id](#input\_app\_id) | Entur app\_id | `string` | n/a | yes |
+| <a name="input_bigquery_remote_function"></a> [bigquery\_remote\_function](#input\_bigquery\_remote\_function) | BigQuery remote function configuration. Creates a BQ connection, grants invoker access, and creates remote function routines. Set to null to disable. | <pre>object({<br/>    connection_id = string<br/>    location      = optional(string, null)<br/>    routines = map(object({<br/>      dataset_id           = string<br/>      routine_type         = optional(string, "SCALAR_FUNCTION")<br/>      description          = optional(string, "")<br/>      user_defined_context = optional(map(string), {})<br/>      arguments = list(object({<br/>        name      = string<br/>        data_type = string<br/>      }))<br/>      return_type = string<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment prd\|dev\|tst | `string` | n/a | yes |
 | <a name="input_function_config"></a> [function\_config](#input\_function\_config) | Cloud Function configuration including runtime, resources, environment variables, and secrets | <pre>object({<br/>    # Function runtime and resources<br/>    runtime                          = optional(string, "python313")<br/>    entry_point                      = optional(string, "main")<br/>    memory_bytes                     = optional(number, 256 * 1024 * 1024)<br/>    cpu_count                        = optional(number, 1)<br/>    timeout_sec                      = optional(number, 1800)<br/>    ingress_settings                 = optional(string, "ALLOW_ALL")<br/>    max_instance_count               = optional(number, 100)<br/>    min_instance_count               = optional(number, 0)<br/>    max_instance_request_concurrency = optional(number, 1)<br/>    description                      = optional(string, "Cloud Function deployed via Terraform")<br/><br/>    # Environment configuration<br/>    environment_variables = optional(map(string), {})<br/>    gsm_secrets           = optional(map(string), {})<br/>  })</pre> | `{}` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | Name of the Cloud Function (will be prefixed with ent-{app\_id}-{env}) | `string` | n/a | yes |
@@ -55,6 +59,9 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_bigquery_connection_name"></a> [bigquery\_connection\_name](#output\_bigquery\_connection\_name) | Full resource name of the BigQuery connection (if created) |
+| <a name="output_bigquery_connection_service_account"></a> [bigquery\_connection\_service\_account](#output\_bigquery\_connection\_service\_account) | Service account email of the BigQuery connection (grant this SA access to Dataform datasets etc.) |
+| <a name="output_bigquery_routine_ids"></a> [bigquery\_routine\_ids](#output\_bigquery\_routine\_ids) | Map of routine key to full resource ID for each BigQuery remote function routine |
 | <a name="output_function_location"></a> [function\_location](#output\_function\_location) | Location/region where the function is deployed |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Name of the deployed Cloud Function |
 | <a name="output_function_uri"></a> [function\_uri](#output\_function\_uri) | URI of the Cloud Function |

--- a/modules/cloudfunctions/bigquery.tf
+++ b/modules/cloudfunctions/bigquery.tf
@@ -29,7 +29,6 @@ resource "google_bigquery_routine" "remote_function" {
   routine_id      = each.key
   routine_type    = each.value.routine_type
   description     = each.value.description
-  language        = ""
   definition_body = ""
 
   dynamic "arguments" {

--- a/modules/cloudfunctions/bigquery.tf
+++ b/modules/cloudfunctions/bigquery.tf
@@ -1,0 +1,50 @@
+# BigQuery remote function resources
+# Creates a BQ connection, grants the connection SA invoker access, and creates remote function routines
+
+resource "google_bigquery_connection" "remote_function" {
+  count         = var.bigquery_remote_function != null ? 1 : 0
+  connection_id = var.bigquery_remote_function.connection_id
+  project       = module.init.app.project_id
+  location      = coalesce(var.bigquery_remote_function.location, var.location)
+
+  cloud_resource {}
+}
+
+resource "google_cloud_run_service_iam_member" "bq_remote_function_invoker" {
+  count    = var.bigquery_remote_function != null ? 1 : 0
+  project  = module.init.app.project_id
+  location = local.location
+  service  = google_cloudfunctions2_function.function.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_bigquery_connection.remote_function[0].cloud_resource[0].service_account_id}"
+
+  depends_on = [google_cloudfunctions2_function.function]
+}
+
+resource "google_bigquery_routine" "remote_function" {
+  for_each = var.bigquery_remote_function != null ? var.bigquery_remote_function.routines : {}
+
+  project         = module.init.app.project_id
+  dataset_id      = each.value.dataset_id
+  routine_id      = each.key
+  routine_type    = each.value.routine_type
+  description     = each.value.description
+  language        = ""
+  definition_body = ""
+
+  dynamic "arguments" {
+    for_each = each.value.arguments
+    content {
+      name      = arguments.value.name
+      data_type = arguments.value.data_type
+    }
+  }
+
+  return_type = each.value.return_type
+
+  remote_function_options {
+    endpoint             = google_cloudfunctions2_function.function.service_config[0].uri
+    connection           = google_bigquery_connection.remote_function[0].name
+    user_defined_context = each.value.user_defined_context
+  }
+}

--- a/modules/cloudfunctions/outputs.tf
+++ b/modules/cloudfunctions/outputs.tf
@@ -45,5 +45,5 @@ output "bigquery_connection_service_account" {
 
 output "bigquery_routine_ids" {
   description = "Map of routine key to full resource ID for each BigQuery remote function routine"
-  value       = { for k, v in google_bigquery_routine.remote_function : k => v.id }
+  value       = var.bigquery_remote_function != null ? { for k, v in google_bigquery_routine.remote_function : k => v.id } : null
 }

--- a/modules/cloudfunctions/outputs.tf
+++ b/modules/cloudfunctions/outputs.tf
@@ -32,3 +32,18 @@ output "scheduler_job_name" {
   description = "Name of the Cloud Scheduler job (if created)"
   value       = try(google_cloud_scheduler_job.scheduler[0].name, null)
 }
+
+output "bigquery_connection_name" {
+  description = "Full resource name of the BigQuery connection (if created)"
+  value       = try(google_bigquery_connection.remote_function[0].name, null)
+}
+
+output "bigquery_connection_service_account" {
+  description = "Service account email of the BigQuery connection (grant this SA access to Dataform datasets etc.)"
+  value       = try(google_bigquery_connection.remote_function[0].cloud_resource[0].service_account_id, null)
+}
+
+output "bigquery_routine_ids" {
+  description = "Map of routine key to full resource ID for each BigQuery remote function routine"
+  value       = { for k, v in google_bigquery_routine.remote_function : k => v.id }
+}

--- a/modules/cloudfunctions/variables.tf
+++ b/modules/cloudfunctions/variables.tf
@@ -75,6 +75,26 @@ variable "labels" {
   default     = {}
 }
 
+variable "bigquery_remote_function" {
+  description = "BigQuery remote function configuration. Creates a BQ connection, grants invoker access, and creates remote function routines. Set to null to disable."
+  type = object({
+    connection_id = string
+    location      = optional(string, null)
+    routines = map(object({
+      dataset_id           = string
+      routine_type         = optional(string, "SCALAR_FUNCTION")
+      description          = optional(string, "")
+      user_defined_context = optional(map(string), {})
+      arguments = list(object({
+        name      = string
+        data_type = string
+      }))
+      return_type = string
+    }))
+  })
+  default = null
+}
+
 variable "pubsub_trigger" {
   description = "Pub/Sub trigger configuration. Set to null to disable Pub/Sub triggering."
   type = object({


### PR DESCRIPTION
Adds optional `bigquery_remote_function` variable that creates a BQ connection, grants invoker access, and creates remote function routines. Follows the existing `scheduler`/`pubsub_trigger` pattern.